### PR TITLE
[SDP-17][Feat] Criar cadastro de torneios

### DIFF
--- a/app/DTO/CreateTournamentDTO.php
+++ b/app/DTO/CreateTournamentDTO.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\DTO;
+
+use App\Http\Requests\StoreTournamentRequest;
+
+class CreateTournamentDTO
+{
+    public function __construct(
+        public string  $name,
+        public ?string $state,
+        public ?string $city,
+        public string  $startDate,
+        public ?string $endDate
+    )
+    {
+    }
+
+    /**
+     * @param StoreTournamentRequest $request
+     * @return CreateTournamentDTO
+     */
+    public static function makeFromRequest(StoreTournamentRequest $request): CreateTournamentDTO
+    {
+        return new self(
+            $request->name,
+            $request->state,
+            $request->city,
+            $request->start_date,
+            $request->end_date
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'state' => $this->state,
+            'city' => $this->city,
+            'start_date' => $this->startDate,
+            'end_date' => $this->endDate
+        ];
+    }
+}

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\DTO\CreateTournamentDTO;
+use App\Http\Requests\StoreTournamentRequest;
+use App\Http\Resources\TournamentResource;
+use App\Services\TournamentService;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class TournamentController extends Controller
+{
+    public function __construct(
+        protected TournamentService $service
+    )
+    {
+    }
+
+    /**
+     * @param StoreTournamentRequest $request
+     * @return TournamentResource
+     */
+    public function store(StoreTournamentRequest $request): TournamentResource
+    {
+        $result = $this->service->create(CreateTournamentDTO::makeFromRequest($request));
+        return new TournamentResource($result);
+    }
+}

--- a/app/Http/Requests/StoreTournamentRequest.php
+++ b/app/Http/Requests/StoreTournamentRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTournamentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|unique:tournaments|max:255',
+            'state' => 'nullable|min:2|max:2',
+            'city' => 'nullable',
+            'start_date' => 'required|date_format:Y-m-d',
+            'end_date' => 'nullable|data_format:Y-m-d|after_or_equal:start_date'
+        ];
+    }
+}

--- a/app/Http/Resources/TournamentResource.php
+++ b/app/Http/Resources/TournamentResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TournamentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Tournament extends Model
 {
     use HasFactory;
+
     protected $fillable = [
         'name',
         'state',
@@ -15,4 +18,18 @@ class Tournament extends Model
         'start_date',
         'end_date'
     ];
+
+    protected function startDate(): Attribute
+    {
+        return Attribute::make(
+            get: fn(string $value) => Carbon::make($value)->format('d/m/Y')
+        );
+    }
+
+    protected function endDate(): Attribute
+    {
+        return Attribute::make(
+            get: fn(?string $value) => $value ? Carbon::make($value)->format('d/m/Y') : null
+        );
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Repositories\Tournament\Eloquent\TournamentRepository;
+use App\Repositories\Tournament\TournamentRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(TournamentRepositoryInterface::class, TournamentRepository::class);
     }
 
     /**

--- a/app/Repositories/Tournament/Eloquent/TournamentRepository.php
+++ b/app/Repositories/Tournament/Eloquent/TournamentRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories\Tournament\Eloquent;
+
+use App\DTO\CreateTournamentDTO;
+use App\Models\Tournament;
+use App\Repositories\Tournament\TournamentRepositoryInterface;
+
+class TournamentRepository implements TournamentRepositoryInterface
+{
+    public function __construct(
+        protected Tournament $model
+    )
+    {
+    }
+
+    public function create(CreateTournamentDTO $createTournamentDTO)
+    {
+        return $this->model->create($createTournamentDTO->toArray());
+    }
+}

--- a/app/Repositories/Tournament/TournamentRepositoryInterface.php
+++ b/app/Repositories/Tournament/TournamentRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Repositories\Tournament;
+
+use App\DTO\CreateTournamentDTO;
+
+interface TournamentRepositoryInterface
+{
+    public function create(CreateTournamentDTO $createTournamentDTO);
+}

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+use App\DTO\CreateTournamentDTO;
+use App\Repositories\Tournament\TournamentRepositoryInterface;
+
+class TournamentService
+{
+    public function __construct(
+        protected TournamentRepositoryInterface $repository
+    )
+    {
+
+    }
+
+    public function create(CreateTournamentDTO $createTournamentDTO)
+    {
+        return $this->repository->create($createTournamentDTO);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Http\Request;
+use App\Http\Controllers\TournamentController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -14,6 +14,4 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::post('/tournaments', [TournamentController::class, 'store'])->name('tournaments.store');


### PR DESCRIPTION
## Motivo da PR
Criar cadastro de torneios 

## O que foi implementado
- Rota [POST] /api/tournaments
- Modificadores na model para start_date e end_date
- Criação do controller, service layer e repository interface
- Criar da request para validar cadastro

## Como testar

```
curl --location 'localhost:8000/api/tournaments' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--data '{
    "name": "Novo Torneio",
    "stdate": "PA",
    "city": "Tucuruí",
    "start_date": "2023-05-23"
}'
```