### PR TITLE
[SDP-18][Feat] Criar endpoint para listar detalhes de um torneio 

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,7 +3,8 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Throwable;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -41,8 +42,12 @@ class Handler extends ExceptionHandler
      */
     public function register(): void
     {
-        $this->reportable(function (Throwable $e) {
-            //
+        $this->renderable(function (NotFoundHttpException $e, Request $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'message' => 'Registro não encontrado'
+                ], $e->getStatusCode());
+            }
         });
     }
 }

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -18,6 +18,19 @@ class TournamentController extends Controller
     }
 
     /**
+     * @param string $id
+     * @return TournamentResource
+     */
+    public function getById(string $id): TournamentResource
+    {
+        if (!$result = $this->service->getById($id)) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        return new TournamentResource($result);
+    }
+
+    /**
      * @param StoreTournamentRequest $request
      * @return TournamentResource
      */

--- a/app/Http/Resources/TournamentResource.php
+++ b/app/Http/Resources/TournamentResource.php
@@ -14,6 +14,15 @@ class TournamentResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'state' => $this->state,
+            'city' => $this->city,
+            'start_date' => $this->start_date,
+            'end_date' => $this->end_date,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at
+        ];
     }
 }

--- a/app/Repositories/Tournament/Eloquent/TournamentRepository.php
+++ b/app/Repositories/Tournament/Eloquent/TournamentRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Tournament\Eloquent;
 use App\DTO\CreateTournamentDTO;
 use App\Models\Tournament;
 use App\Repositories\Tournament\TournamentRepositoryInterface;
+use stdClass;
 
 class TournamentRepository implements TournamentRepositoryInterface
 {
@@ -12,6 +13,20 @@ class TournamentRepository implements TournamentRepositoryInterface
         protected Tournament $model
     )
     {
+    }
+
+    /**
+     * @param string $id
+     * @return stdClass|null
+     */
+    public function getById(string $id): ?stdClass
+    {
+        $tournament = $this->model->find($id);
+        if (!$tournament) {
+            return null;
+        }
+
+        return (object)$tournament->toArray();
     }
 
     public function create(CreateTournamentDTO $createTournamentDTO)

--- a/app/Repositories/Tournament/TournamentRepositoryInterface.php
+++ b/app/Repositories/Tournament/TournamentRepositoryInterface.php
@@ -3,8 +3,11 @@
 namespace App\Repositories\Tournament;
 
 use App\DTO\CreateTournamentDTO;
+use stdClass;
 
 interface TournamentRepositoryInterface
 {
+    public function getById(string $id): ?stdClass;
+
     public function create(CreateTournamentDTO $createTournamentDTO);
 }

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\DTO\CreateTournamentDTO;
 use App\Repositories\Tournament\TournamentRepositoryInterface;
+use stdClass;
 
 class TournamentService
 {
@@ -14,7 +15,20 @@ class TournamentService
 
     }
 
-    public function create(CreateTournamentDTO $createTournamentDTO)
+    /**
+     * @param string $id
+     * @return stdClass|null
+     */
+    public function getById(string $id): ?stdClass
+    {
+        return $this->repository->getById($id);
+    }
+
+    /**
+     * @param CreateTournamentDTO $createTournamentDTO
+     * @return mixed
+     */
+    public function create(CreateTournamentDTO $createTournamentDTO): mixed
     {
         return $this->repository->create($createTournamentDTO);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,4 +14,5 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::get('/tournaments/{tournament_id}', [TournamentController::class, 'getById'])->name('tournaments.getById');
 Route::post('/tournaments', [TournamentController::class, 'store'])->name('tournaments.store');


### PR DESCRIPTION
## Motivo da PR
Listar detalhes de um torneio especifico, se não encontrar retornar 404

## O que foi implementado
- Criação na rota [GET] /api/tournaments/{tournament_id}
- Criação do controller, service layer e repository interface
- Alteração da resource para suportar stdClass

## Como testar

```
curl --location 'localhost:8000/api/tournaments/1'
```