### PR TITLE
[SDP-19][Feat] Criar endpoint para atualizar torneio

### DIFF
--- a/app/DTO/Tournament/CreateTournamentDTO.php
+++ b/app/DTO/Tournament/CreateTournamentDTO.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\DTO;
+namespace App\DTO\Tournament;
 
-use App\Http\Requests\StoreTournamentRequest;
+use App\Http\Requests\StoreUpdateTournamentRequest;
 
 class CreateTournamentDTO
 {
@@ -17,10 +17,10 @@ class CreateTournamentDTO
     }
 
     /**
-     * @param StoreTournamentRequest $request
+     * @param StoreUpdateTournamentRequest $request
      * @return CreateTournamentDTO
      */
-    public static function makeFromRequest(StoreTournamentRequest $request): CreateTournamentDTO
+    public static function makeFromRequest(StoreUpdateTournamentRequest $request): CreateTournamentDTO
     {
         return new self(
             $request->name,

--- a/app/DTO/Tournament/UpdateTournamentDTO.php
+++ b/app/DTO/Tournament/UpdateTournamentDTO.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\DTO\Tournament;
+
+use Illuminate\Http\Request;
+
+class UpdateTournamentDTO
+{
+    public function __construct(
+        public int     $id,
+        public string  $name,
+        public ?string $state,
+        public ?string $city,
+        public string  $startDate,
+        public ?string $endDate
+    )
+    {
+    }
+
+    /**
+     * @param Request $request
+     * @param int $id
+     * @return UpdateTournamentDTO
+     */
+    public static function makeFromRequest(Request $request, int $id): UpdateTournamentDTO
+    {
+        return new self(
+            $id,
+            $request->name,
+            $request->state,
+            $request->city,
+            $request->start_date,
+            $request->end_date
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'state' => $this->state,
+            'city' => $this->city,
+            'start_date' => $this->startDate,
+            'end_date' => $this->endDate
+        ];
+    }
+}

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use App\DTO\CreateTournamentDTO;
-use App\Http\Requests\StoreTournamentRequest;
+use App\DTO\Tournament\CreateTournamentDTO;
+use App\DTO\Tournament\UpdateTournamentDTO;
+use App\Http\Requests\StoreUpdateTournamentRequest;
 use App\Http\Resources\TournamentResource;
 use App\Services\TournamentService;
-use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class TournamentController extends Controller
@@ -31,12 +31,26 @@ class TournamentController extends Controller
     }
 
     /**
-     * @param StoreTournamentRequest $request
+     * @param StoreUpdateTournamentRequest $request
      * @return TournamentResource
      */
-    public function store(StoreTournamentRequest $request): TournamentResource
+    public function store(StoreUpdateTournamentRequest $request): TournamentResource
     {
         $result = $this->service->create(CreateTournamentDTO::makeFromRequest($request));
+        return new TournamentResource($result);
+    }
+
+    /**
+     * @param StoreUpdateTournamentRequest $request
+     * @param int $id
+     * @return TournamentResource
+     */
+    public function update(StoreUpdateTournamentRequest $request, int $id): TournamentResource
+    {
+        if (!$result = $this->service->update(UpdateTournamentDTO::makeFromRequest($request, $id))) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
         return new TournamentResource($result);
     }
 }

--- a/app/Http/Requests/StoreUpdateTournamentRequest.php
+++ b/app/Http/Requests/StoreUpdateTournamentRequest.php
@@ -3,8 +3,9 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
-class StoreTournamentRequest extends FormRequest
+class StoreUpdateTournamentRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,12 +22,22 @@ class StoreTournamentRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        $rules = [
             'name' => 'required|unique:tournaments|max:255',
             'state' => 'nullable|min:2|max:2',
             'city' => 'nullable',
             'start_date' => 'required|date_format:Y-m-d',
             'end_date' => 'nullable|data_format:Y-m-d|after_or_equal:start_date'
         ];
+
+        if ($this->method() == 'PUT' || $this->method() == 'PATCH') {
+            $rules['name'] = [
+                'required',
+                'max:255',
+                Rule::unique('tournaments')->ignore($this->tournament_id)
+            ];
+        }
+
+        return $rules;
     }
 }

--- a/app/Repositories/Tournament/Eloquent/TournamentRepository.php
+++ b/app/Repositories/Tournament/Eloquent/TournamentRepository.php
@@ -2,7 +2,8 @@
 
 namespace App\Repositories\Tournament\Eloquent;
 
-use App\DTO\CreateTournamentDTO;
+use App\DTO\Tournament\CreateTournamentDTO;
+use App\DTO\Tournament\UpdateTournamentDTO;
 use App\Models\Tournament;
 use App\Repositories\Tournament\TournamentRepositoryInterface;
 use stdClass;
@@ -29,8 +30,28 @@ class TournamentRepository implements TournamentRepositoryInterface
         return (object)$tournament->toArray();
     }
 
-    public function create(CreateTournamentDTO $createTournamentDTO)
+    /**
+     * @param CreateTournamentDTO $createTournamentDTO
+     * @return stdClass|null
+     */
+    public function create(CreateTournamentDTO $createTournamentDTO): ?stdClass
     {
-        return $this->model->create($createTournamentDTO->toArray());
+        return (object)$this->model->create($createTournamentDTO->toArray());
+    }
+
+    /**
+     * @param UpdateTournamentDTO $updateTournamentDTO
+     * @return stdClass|null
+     */
+    public function update(UpdateTournamentDTO $updateTournamentDTO): ?stdClass
+    {
+        $tournament = $this->model->find($updateTournamentDTO->id);
+        if (!$tournament) {
+            return null;
+        }
+
+        $tournament->update($updateTournamentDTO->toArray());
+
+        return (object)$tournament->toArray();
     }
 }

--- a/app/Repositories/Tournament/TournamentRepositoryInterface.php
+++ b/app/Repositories/Tournament/TournamentRepositoryInterface.php
@@ -2,12 +2,15 @@
 
 namespace App\Repositories\Tournament;
 
-use App\DTO\CreateTournamentDTO;
+use App\DTO\Tournament\CreateTournamentDTO;
+use App\DTO\Tournament\UpdateTournamentDTO;
 use stdClass;
 
 interface TournamentRepositoryInterface
 {
     public function getById(string $id): ?stdClass;
 
-    public function create(CreateTournamentDTO $createTournamentDTO);
+    public function create(CreateTournamentDTO $createTournamentDTO): ?stdClass;
+
+    public function update(UpdateTournamentDTO $updateTournamentDTO): ?stdClass;
 }

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -2,7 +2,8 @@
 
 namespace App\Services;
 
-use App\DTO\CreateTournamentDTO;
+use App\DTO\Tournament\CreateTournamentDTO;
+use App\DTO\Tournament\UpdateTournamentDTO;
 use App\Repositories\Tournament\TournamentRepositoryInterface;
 use stdClass;
 
@@ -26,10 +27,20 @@ class TournamentService
 
     /**
      * @param CreateTournamentDTO $createTournamentDTO
-     * @return mixed
+     * @return stdClass|null
      */
-    public function create(CreateTournamentDTO $createTournamentDTO): mixed
+    public function create(CreateTournamentDTO $createTournamentDTO): ?stdClass
     {
         return $this->repository->create($createTournamentDTO);
+    }
+
+
+    /**
+     * @param UpdateTournamentDTO $updateTournamentDTO
+     * @return stdClass|null
+     */
+    public function update(UpdateTournamentDTO $updateTournamentDTO): ?stdClass
+    {
+        return $this->repository->update($updateTournamentDTO);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,3 +16,4 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/tournaments/{tournament_id}', [TournamentController::class, 'getById'])->name('tournaments.getById');
 Route::post('/tournaments', [TournamentController::class, 'store'])->name('tournaments.store');
+Route::put('/tournaments/{tournament_id}', [TournamentController::class, 'update'])->name('tournaments.update');


### PR DESCRIPTION
## Motivo da PR
Criar endpoint para atualizar torneio, se não encontrar o registro deve retornar 404

## O que foi implementado
- Criação da rota [PUT] /api/tournaments/{tournament_id}
- Criação do metodo no controller, service layer e repository interface
- Modifica form request para ser utilizado na criação e atualização de torneios

## Como testar

```
curl --location --request PUT 'localhost:8000/api/tournaments/23' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--data '{
    "name": "Novo Torneio 23",
    "state": "PA",
    "city": "Tucuruí",
    "start_date": "2023-05-24"
}'
```