### PR TITLE
feat(SDP-22): Cria seeder para categorias

### DIFF
--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('categories')->insert([
+            'name' => 'Categoria Especial - Modalidade Arremesso',
+            'created_at' => Carbon::now()
+        ]);
+
+        DB::table('categories')->insert([
+            'name' => 'Categoria Comum - Modalidade Arremesso e Corrico',
+            'created_at' => Carbon::now()
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,7 +12,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
-            TournamentSeeder::class
+            TournamentSeeder::class,
+            CategorySeeder::class,
         ]);
     }
 }


### PR DESCRIPTION
## Motivo da PR
- Popular tabela **categories** através da seeder CategorySeeder
- Task: https://brothersdev.atlassian.net/browse/SDP-22

## O que foi implementado
- Criação da seeder CategorySeeder com os dados das duas categorias

## Como testar
- Executar: `php artisan db:seed --class=CategorySeeder`