### PR TITLE
refactor: devolve relacionamento com categorias na listagem de equipes

### DIFF
--- a/app/Repositories/Team/Eloquent/TeamRepository.php
+++ b/app/Repositories/Team/Eloquent/TeamRepository.php
@@ -21,7 +21,7 @@ class TeamRepository implements TeamRepositoryInterface
      */
     public function all(): array
     {
-        return $this->model->all()->toArray();
+        return $this->model->with('category')->get()->toArray();
     }
 
     /**
@@ -30,7 +30,7 @@ class TeamRepository implements TeamRepositoryInterface
      */
     public function getById(int $id): ?stdClass
     {
-        $team = $this->model->find($id);
+        $team = $this->model->with('category')->find($id);
         if (!$team) {
             return null;
         }


### PR DESCRIPTION
## Motivo da PR
- Necessidade de saber o nome da categoria na listagem de equipes