### PR TITLE
Refactor: Remove campo de categoria das tabelas de Equipes e Apurações.

### DIFF
--- a/frontend/src/app/views/screenskit/teams/AppTeams.jsx
+++ b/frontend/src/app/views/screenskit/teams/AppTeams.jsx
@@ -40,15 +40,6 @@ export default function AppTeams() {
                 disableClickEventBubbling: true,
             },
             {
-                field: "category",
-                headerName: "Categoria",
-                width: 400,
-                disableClickEventBubbling: true,
-                valueGetter: (params) => {
-                    return `${params?.row.category.name}`;
-                },
-            },
-            {
                 headerName: "Ações",
                 width: 90,
                 renderCell: (params) => (

--- a/frontend/src/app/views/screenskit/verification/AppVerification.jsx
+++ b/frontend/src/app/views/screenskit/verification/AppVerification.jsx
@@ -46,15 +46,6 @@ export default function AppVerification() {
                 disableClickEventBubbling: true,
             },
             {
-                field: "category",
-                headerName: "Categoria",
-                width: 350,
-                disableClickEventBubbling: true,
-                valueGetter: (params) => {
-                    return `${params?.row.team.category.name}`;
-                },
-            },
-            {
                 headerName: "Ações",
                 width: 90,
                 flex: 1,


### PR DESCRIPTION
## [Front] Remover campo “Categoria” na tela de listagem de equipes e apurações
> Removido a coluna de categoria das tabelas de Equipes e de Apurações